### PR TITLE
Fix linker warnings in Xcode

### DIFF
--- a/DarklyEventSource.podspec
+++ b/DarklyEventSource.podspec
@@ -7,8 +7,6 @@ Pod::Spec.new do |s|
 	s.author       = { "Neil Cowburn" => "git@neilcowburn.com" }
 	s.source       = { :git => "https://github.com/launchdarkly/ios-eventsource.git", :tag => "1.3.1" }
 	s.source_files = 'EventSource', 'EventSource/EventSource.{h,m}'
-	s.ios.xcconfig = { 'FRAMEWORK_SEARCH_PATHS' => '$(inherited) "$(SDKROOT)/Developer/Library/Frameworks" "$(DEVELOPER_LIBRARY_DIR)/Frameworks"' }
-	s.osx.xcconfig = { 'FRAMEWORK_SEARCH_PATHS' => '$(inherited) "$(DEVELOPER_LIBRARY_DIR)/Frameworks"' }
 	s.ios.deployment_target = '8.0'
 	s.osx.deployment_target = '10.7'
 	s.watchos.deployment_target = '2.0'


### PR DESCRIPTION
These paths change with almost every version of Xcode and CocoaPods should be responsible for managing this rather then the pod itself
![screen shot 2017-05-22 at 4 28 06 pm](https://cloud.githubusercontent.com/assets/7799267/26330942/ab010e12-3f0b-11e7-8bd2-f4640d566b69.png)
