### PR TITLE
Fix big frames

### DIFF
--- a/EventSource/EventSource.m
+++ b/EventSource/EventSource.m
@@ -243,7 +243,12 @@ didReceiveResponse:(NSURLResponse *)response completionHandler:(void (^)(NSURLSe
     if (self.session) {
         [self.session invalidateAndCancel];
     }
-    self.session = [NSURLSession sessionWithConfiguration:[NSURLSessionConfiguration ephemeralSessionConfiguration]
+
+    NSURLSessionConfiguration * config = [NSURLSessionConfiguration ephemeralSessionConfiguration];
+
+    config.HTTPAdditionalHeaders = @{ @"Accept": @"text/event-stream" };
+
+    self.session = [NSURLSession sessionWithConfiguration:config
                                                  delegate:self
                                             delegateQueue:[NSOperationQueue currentQueue]];
     


### PR DESCRIPTION
I noticed that I was having a hard time receiving EventSource data from WebPack's Hot Module Replacement function.  It was being caused by two small issues, a missing Accept: header, and trying to parse large frames (sent with two callbacks) as separate frames.  The solution I have here isn't ideal, as I don't have the time to do it "right" (regexp parsing strings?), but it does work for WebPack HMR.