### PR TITLE
Generic HTTP Headers

### DIFF
--- a/DarklyEventSource.podspec
+++ b/DarklyEventSource.podspec
@@ -1,11 +1,11 @@
 Pod::Spec.new do |s|
 	s.name         = "DarklyEventSource"
-	s.version      = "1.3.3"
+	s.version      = "2.0.0"
 	s.summary      = "HTML5 Server-Sent Events in your Cocoa app."
 	s.homepage     = "https://github.com/launchdarkly/ios-eventsource"
 	s.license      = 'MIT (see LICENSE.txt)'
 	s.author       = { "Neil Cowburn" => "git@neilcowburn.com" }
-	s.source       = { :git => "https://github.com/launchdarkly/ios-eventsource.git", :tag => "1.3.3" }
+	s.source       = { :git => "https://github.com/launchdarkly/ios-eventsource.git", :tag => "2.0.0" }
 	s.source_files = 'EventSource', 'EventSource/EventSource.{h,m}'
 	s.ios.deployment_target = '8.0'
 	s.osx.deployment_target = '10.7'

--- a/DarklyEventSource.podspec
+++ b/DarklyEventSource.podspec
@@ -1,11 +1,11 @@
 Pod::Spec.new do |s|
 	s.name         = "DarklyEventSource"
-	s.version      = "1.3.2"
+	s.version      = "1.3.3"
 	s.summary      = "HTML5 Server-Sent Events in your Cocoa app."
 	s.homepage     = "https://github.com/launchdarkly/ios-eventsource"
 	s.license      = 'MIT (see LICENSE.txt)'
 	s.author       = { "Neil Cowburn" => "git@neilcowburn.com" }
-	s.source       = { :git => "https://github.com/launchdarkly/ios-eventsource.git", :tag => "1.3.2" }
+	s.source       = { :git => "https://github.com/launchdarkly/ios-eventsource.git", :tag => "1.3.3" }
 	s.source_files = 'EventSource', 'EventSource/EventSource.{h,m}'
 	s.ios.deployment_target = '8.0'
 	s.osx.deployment_target = '10.7'

--- a/EventSource/EventSource.h
+++ b/EventSource/EventSource.h
@@ -45,28 +45,28 @@ typedef void (^EventSourceEventHandler)(Event *event);
 /// Returns a new instance of EventSource with the specified URL.
 ///
 /// @param URL The URL of the EventSource.
-/// @param mobileKey The mobile key to be included in the authorization header
-+ (instancetype)eventSourceWithURL:(NSURL *)URL mobileKey:(NSString *)mobileKey;
+/// @param headers The http headers to be included
++ (instancetype)eventSourceWithURL:(NSURL *)URL httpHeaders:(NSDictionary<NSString*, NSString *>*) headers;
 
 /// Returns a new instance of EventSource with the specified URL.
 ///
 /// @param URL The URL of the EventSource.
-/// @param mobileKey The mobile key to be included in the authorization header
+/// @param headers The http headers to be included
 /// @param timeoutInterval The request timeout interval in seconds. See <tt>NSURLRequest</tt> for more details. Default: 5 minutes.
-+ (instancetype)eventSourceWithURL:(NSURL *)URL mobileKey:(NSString *)mobileKey timeoutInterval:(NSTimeInterval)timeoutInterval;
++ (instancetype)eventSourceWithURL:(NSURL *)URL httpHeaders:(NSDictionary<NSString*, NSString *>*) headers timeoutInterval:(NSTimeInterval)timeoutInterval;
 
 /// Creates a new instance of EventSource with the specified URL.
 ///
 /// @param URL The URL of the EventSource.
-/// @param mobileKey The mobile key to be included in the authorization header
-- (instancetype)initWithURL:(NSURL *)URL mobileKey:(NSString *)mobileKey;
+/// @param headers The http headers to be included
+- (instancetype)initWithURL:(NSURL *)URL httpHeaders:(NSDictionary<NSString*, NSString *>*) headers;
 
 /// Creates a new instance of EventSource with the specified URL.
 ///
 /// @param URL The URL of the EventSource.
-/// @param mobileKey The mobile key to be included in the authorization header
+/// @param headers The http headers to be included
 /// @param timeoutInterval The request timeout interval in seconds. See <tt>NSURLRequest</tt> for more details. Default: 5 minutes.
-- (instancetype)initWithURL:(NSURL *)URL mobileKey:(NSString *)mobileKey timeoutInterval:(NSTimeInterval)timeoutInterval;
+- (instancetype)initWithURL:(NSURL *)URL httpHeaders:(NSDictionary<NSString*, NSString *>*) headers timeoutInterval:(NSTimeInterval)timeoutInterval;
 
 /// Registers an event handler for the Message event.
 ///

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ source 'https://github.com/CocoaPods/Specs.git'
 platform :ios, '8.0'
 
 target 'TargetName' do
-pod 'DarklyEventSource', '~> 1.3.2'
+pod 'DarklyEventSource', '~> 1.3.3'
 end
 ```
 
@@ -117,7 +117,7 @@ $ brew install carthage
 To integrate EventSource into your Xcode project using Carthage, specify it in your `Cartfile`:
 
 ```ogdl
-github "launchdarkly/ios-eventsource" ~> 1.3.2
+github "launchdarkly/ios-eventsource" ~> 1.3.3
 ```
 
 Run `carthage` to build the framework and drag the built `EventSource.framework` into your Xcode project.

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ source 'https://github.com/CocoaPods/Specs.git'
 platform :ios, '8.0'
 
 target 'TargetName' do
-pod 'DarklyEventSource', '~> 1.3.3'
+pod 'DarklyEventSource', '~> 2.0.0'
 end
 ```
 
@@ -117,7 +117,7 @@ $ brew install carthage
 To integrate EventSource into your Xcode project using Carthage, specify it in your `Cartfile`:
 
 ```ogdl
-github "launchdarkly/ios-eventsource" ~> 1.3.3
+github "launchdarkly/ios-eventsource" ~> 2.0.0
 ```
 
 Run `carthage` to build the framework and drag the built `EventSource.framework` into your Xcode project.


### PR DESCRIPTION
This PR intends to remove the specific header passed to the event source and replace with a generic NSDictionary to allow multiple headers to be sent directly to the event source for multiple headers and better scalability.