### PR TITLE
Connect Using an Arbitrary Method & Data

### DIFF
--- a/DarklyEventSource.podspec
+++ b/DarklyEventSource.podspec
@@ -1,11 +1,11 @@
 Pod::Spec.new do |s|
 	s.name         = "DarklyEventSource"
-	s.version      = "3.1.2"
+	s.version      = "3.2.0"
 	s.summary      = "HTML5 Server-Sent Events in your Cocoa app."
 	s.homepage     = "https://github.com/launchdarkly/ios-eventsource"
 	s.license      = 'MIT (see LICENSE.txt)'
 	s.author       = { "Neil Cowburn" => "git@neilcowburn.com" }
-	s.source       = { :git => "https://github.com/launchdarkly/ios-eventsource.git", :tag => '3.1.2' }
+	s.source       = { :git => "https://github.com/launchdarkly/ios-eventsource.git", :tag => '3.2.0' }
 	s.source_files = 'LDEventSource', 'LDEventSource/LDEventSource.{h,m}'
 	s.ios.deployment_target = '8.0'
 	s.osx.deployment_target = '10.10'

--- a/LDEventSource/Info.plist
+++ b/LDEventSource/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.1.2</string>
+	<string>3.2.0</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/LDEventSource/LDEventSource.h
+++ b/LDEventSource/LDEventSource.h
@@ -54,8 +54,18 @@ typedef void (^LDEventSourceEventHandler)(LDEvent *event);
 ///
 /// @param URL The URL of the EventSource.
 /// @param headers The http headers to be included
+/// @param connectMethod The http method to use to connect to the EventSource. Default: GET
+/// @param connectBody The http body to use to connect to the EventSource. Default: nil
++ (instancetype)eventSourceWithURL:(NSURL *)URL httpHeaders:(NSDictionary<NSString*, NSString *>*)headers connectMethod:(NSString*)connectMethod connectBody:(NSData*)connectBody;
+
+/// Returns a new instance of EventSource with the specified URL.
+///
+/// @param URL The URL of the EventSource.
+/// @param headers The http headers to be included
 /// @param timeoutInterval The request timeout interval in seconds. See <tt>NSURLRequest</tt> for more details. Default: 5 minutes.
-+ (instancetype)eventSourceWithURL:(NSURL *)URL httpHeaders:(NSDictionary<NSString*, NSString *>*) headers timeoutInterval:(NSTimeInterval)timeoutInterval;
+/// @param connectMethod The http method to use to connect to the EventSource. Default: GET
+/// @param connectBody The http body to use to connect to the EventSource. Default: nil
++ (instancetype)eventSourceWithURL:(NSURL *)URL httpHeaders:(NSDictionary<NSString*, NSString *>*)headers timeoutInterval:(NSTimeInterval)timeoutInterval connectMethod:(NSString*)connectMethod connectBody:(NSData*)connectBody;
 
 /// Creates a new instance of EventSource with the specified URL.
 ///
@@ -67,8 +77,18 @@ typedef void (^LDEventSourceEventHandler)(LDEvent *event);
 ///
 /// @param URL The URL of the EventSource.
 /// @param headers The http headers to be included
+/// @param connectMethod The http method to use to connect to the EventSource. Default: GET
+/// @param connectBody The http body to use to connect to the EventSource. Default: nil
+- (instancetype)initWithURL:(NSURL *)URL httpHeaders:(NSDictionary<NSString*, NSString *>*) headers connectMethod:(NSString*)connectMethod connectBody:(NSData*)connectBody;
+
+/// Creates a new instance of EventSource with the specified URL.
+///
+/// @param URL The URL of the EventSource.
+/// @param headers The http headers to be included
 /// @param timeoutInterval The request timeout interval in seconds. See <tt>NSURLRequest</tt> for more details. Default: 5 minutes.
-- (instancetype)initWithURL:(NSURL *)URL httpHeaders:(NSDictionary<NSString*, NSString *>*) headers timeoutInterval:(NSTimeInterval)timeoutInterval;
+/// @param connectMethod The http method to use to connect to the EventSource. Default: GET
+/// @param connectBody The http body to use to connect to the EventSource. Default: nil
+- (instancetype)initWithURL:(NSURL *)URL httpHeaders:(NSDictionary<NSString*, NSString *>*) headers timeoutInterval:(NSTimeInterval)timeoutInterval connectMethod:(NSString*)connectMethod connectBody:(NSData*)connectBody;
 
 /// Registers an event handler for the Message event.
 ///

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ EventSource *source = [EventSource eventSourceWithURL:serverURL];
 
 #### Listening for Connection State Changes
 
-Additionally, there are `onOpen:`,  `onError:`, and `onReadyStateChanged:` methods to receive connection state events. 
+Additionally, there are `onOpen:`, `onMessage`, `onError:`, and `onReadyStateChanged:` methods to receive connection state events.
 
 ```objc
 NSURL *serverURL = [NSURL URLWithString:@"http://127.0.0.1:8000/"];

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,3 @@
+test:
+  override:
+    - echo "No tests are defined for LDEventSource."


### PR DESCRIPTION
## Summary
Adds the ability to connect to the event source using a connect method and data provided via new initializers. These are both optional parameters.

## How to test
Test by connecting the sdk and sample app to this version. No change should be needed in either for the event source to function correctly.

- [n/a] Adds unit tests as appropriate
- [X] Works on sample apps
- [x] Works on a real device

## Areas of the code affected
- Initialization & streaming connection
