### PR TITLE
Preclude potential retain cycles

### DIFF
--- a/DarklyEventSource.podspec
+++ b/DarklyEventSource.podspec
@@ -1,11 +1,11 @@
 Pod::Spec.new do |s|
 	s.name         = "DarklyEventSource"
-	s.version      = "3.2.2"
+	s.version      = "3.2.3"
 	s.summary      = "HTML5 Server-Sent Events in your Cocoa app."
 	s.homepage     = "https://github.com/launchdarkly/ios-eventsource"
 	s.license      = 'MIT (see LICENSE.txt)'
 	s.author       = { "Neil Cowburn" => "git@neilcowburn.com" }
-	s.source       = { :git => "https://github.com/launchdarkly/ios-eventsource.git", :tag => '3.2.2' }
+	s.source       = { :git => "https://github.com/launchdarkly/ios-eventsource.git", :tag => '3.2.3' }
 	s.source_files = 'LDEventSource', 'LDEventSource/LDEventSource.{h,m}'
 	s.ios.deployment_target = '8.0'
 	s.osx.deployment_target = '10.10'

--- a/LDEventSource/Info.plist
+++ b/LDEventSource/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.2.2</string>
+	<string>3.2.3</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/LDEventSource/LDEventSource.m
+++ b/LDEventSource/LDEventSource.m
@@ -93,8 +93,9 @@ static NSInteger const HTTPStatusCodeUnauthorized = 401;
         connectionQueue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0);
         
         dispatch_time_t popTime = dispatch_time(DISPATCH_TIME_NOW, (int64_t)(_retryInterval * NSEC_PER_SEC));
+        __weak typeof(self) weakSelf = self;
         dispatch_after(popTime, connectionQueue, ^(void){
-            [self _open];
+            [weakSelf _open];
         });
     }
     return self;
@@ -170,8 +171,9 @@ didReceiveResponse:(NSURLResponse *)response completionHandler:(void (^)(NSURLSe
         }
         
         if (!line || line.length == 0) {
+            __weak typeof(self) weakSelf = self;
             dispatch_async(messageQueue, ^{
-                [self _dispatchEvent:event];
+                [weakSelf _dispatchEvent:event];
             });
             
             event = [LDEvent new];
@@ -225,8 +227,9 @@ didReceiveResponse:(NSURLResponse *)response completionHandler:(void (^)(NSURLSe
     
     if (![self responseIsUnauthorizedForTask:task]) {
         dispatch_time_t popTime = dispatch_time(DISPATCH_TIME_NOW, (int64_t)([self increaseIntervalWithBackoff] * NSEC_PER_SEC));
+        __weak typeof(self) weakSelf = self;
         dispatch_after(popTime, connectionQueue, ^(void){
-            [self _open];
+            [weakSelf _open];
         });
     }
 }

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ source 'https://github.com/CocoaPods/Specs.git'
 platform :ios, '8.0'
 
 target 'TargetName' do
-pod 'DarklyEventSource', '~> 3.2.2'
+pod 'DarklyEventSource', '~> 3.2.3'
 end
 ```
 
@@ -117,7 +117,7 @@ $ brew install carthage
 To integrate EventSource into your Xcode project using Carthage, specify it in your `Cartfile`:
 
 ```ogdl
-github "launchdarkly/ios-eventsource" >= 3.2.2
+github "launchdarkly/ios-eventsource" >= 3.2.3
 ```
 
 Run `carthage` to build the framework and drag the built `EventSource.framework` into your Xcode project.


### PR DESCRIPTION
## Connects
•[EXC_BAD_ACCESS KERN_INVALID_ADDRESS 0x0000000000000020](https://github.com/launchdarkly/ios-client/issues/131)

## Summary
Changes references to self in blocks to `__weak` to allow the OS to release the LDEventSource without calling the method in the block.

## How to test
### Test Notes
•Launching the SDK in streaming mode initializes the LDEventSource after a 1 second delay. 
•The SDK configures 2 types of event listeners on LDEventSource, one that listens for streaming events, and another that listens for error events. The test steps will verify that the LDEventSource can execute both listeners. The following areas were changed by the weak references:
-Dispatching event stream messages (`put`, `patch`, & `delete`)
-Opening the `clientstream` connection on intialization after a 1 second delay.
-Listening for errors on the `clientstream` connection, which launches a new connection after a delay. **NOTE**: 401 Unauthorized errors cause the LDEventSource not to try the connection again.
### Test Setup
1. Use the provided sample app, which is configured for streaming and pointed to SDK version `2.11.1`. Note that this is a macOS app, which means that the event source will exist only when the app window has the focus. 
2. Configure a web proxy to monitor app communications.
3. Use a 2nd device to login to the LD dashboard. That allows you to change flag values without removing the focus from the sample app window. Select the `Test` project `Test` environment.
### Test Steps
1. With the web proxy window visible, launch the sample app. On the web proxy, verify the sample app connects to the `clientstream`.
2. On the LD dashboard, change the value of the `test-flag`. Verify the sample app shows the new value.
3. Remove the focus from the sample app. In Xcode, verify the LDEventSource disconnected the connection by finding a log message similar to the following:
```
Task <D586FD51-611F-401B-85DB-8DB67727EC7A>.<1> finished with error - code: -999
```
4. On the LD Dashboard, change the value of `test-flag`. Verify the sample app does not show the changed value.
5. Kill the sample app.
6. Launch the sample app, and right away remove focus from the sample app window. On the web proxy, verify the sample app did not make a `clientstream` connection. **NOTE** The previous connection may appear active on the web proxy. You can confirm that only 1 connection was made, or that the last previous connection was prior to the launch time.
7. Kill the sample app.
8. In Xcode, in the sample app `ViewController.swift`, uncomment the line for the `MOBILE_KEY` and comment out the uncommented `MOBILE_KEY` constant definition. In this configuration, the SDK should only try the `clientstream` connection one time, regardless of the number of times the sample app window regains the focus.
9. Launch the sample app. On the web proxy, verify the sample app attempted a `clientstream` connection. Verify the server returned a `401 Unauthorized`.
10. Remove focus from the sample app window.
11. Return focus to the sample app window. Verify the SDK does not attempt another `clientstream` connection.
12. Kill the sample app.
13. In Xcode, restore the original `MOBILE_KEY` definition. Uncomment the line to change the `streamUrl` to `dummy.launchdarkly.com`.
14. Launch the sample app. Verify the LDEventSource makes multiple attempts to connect. 

- [n/a] Adds unit tests as appropriate. There are no automated ios-eventsource tests
- [x] Works on sample apps
- [x] Works on a real device

## Areas of the sdk affected
- Streaming Events