### PR TITLE
Version 3.2.7

### DIFF
--- a/DarklyEventSource.podspec
+++ b/DarklyEventSource.podspec
@@ -1,11 +1,11 @@
 Pod::Spec.new do |s|
 	s.name         = "DarklyEventSource"
-	s.version      = "3.2.6"
+	s.version      = "3.2.7"
 	s.summary      = "HTML5 Server-Sent Events in your Cocoa app."
 	s.homepage     = "https://github.com/launchdarkly/ios-eventsource"
 	s.license      = 'MIT (see LICENSE.txt)'
 	s.author       = { "Neil Cowburn" => "git@neilcowburn.com" }
-	s.source       = { :git => "https://github.com/launchdarkly/ios-eventsource.git", :tag => '3.2.6' }
+	s.source       = { :git => "https://github.com/launchdarkly/ios-eventsource.git", :tag => '3.2.7' }
 	s.source_files = 'LDEventSource/**/*.{h,m}'
 	s.ios.deployment_target = '8.0'
 	s.osx.deployment_target = '10.10'

--- a/DarklyEventSourceTests/Categories/LDEventSource+Testable.h
+++ b/DarklyEventSourceTests/Categories/LDEventSource+Testable.h
@@ -8,8 +8,11 @@
 
 #import <Foundation/Foundation.h>
 #import "LDEventSource.h"
+#import "LDEventStringAccumulator.h"
 
 @interface LDEventSource(Testable)
 @property (nonatomic, strong) NSURLSessionDataTask *eventSourceTask;
 @property (nonatomic, strong) NSURLSession *session;
+@property (nonatomic, strong) LDEventStringAccumulator *eventStringAccumulator;
+
 @end

--- a/DarklyEventSourceTests/Categories/LDEventSource+Testable.m
+++ b/DarklyEventSourceTests/Categories/LDEventSource+Testable.m
@@ -11,4 +11,5 @@
 @implementation LDEventSource(Testable)
 @dynamic eventSourceTask;
 @dynamic session;
+@dynamic eventStringAccumulator;
 @end

--- a/DarklyEventSourceTests/LDEventParserTest.m
+++ b/DarklyEventSourceTests/LDEventParserTest.m
@@ -10,6 +10,7 @@
 #import <Foundation/Foundation.h>
 #import "LDEventSource.h"
 #import "LDEventParser.h"
+#import "NSString+LDEventSource.h"
 #import "NSString+Testable.h"
 
 @interface LDEventParserTest : XCTestCase
@@ -31,5 +32,18 @@
     XCTAssertEqual(event.readyState, kEventStateOpen);
     XCTAssertNil(parser.remainingEventString);
     XCTAssertNil(parser.retryInterval);
+}
+
+-(void)testHasEventTerminator_shortString {
+    NSString *eventString = nil;
+    XCTAssertFalse(eventString.hasEventTerminator);
+    eventString = @"";
+    XCTAssertFalse(eventString.hasEventTerminator);
+    eventString = @"\n";
+    XCTAssertFalse(eventString.hasEventTerminator);
+    eventString = @"\n\0";
+    XCTAssertFalse(eventString.hasEventTerminator);
+    eventString = @"\n\n";
+    XCTAssertTrue(eventString.hasEventTerminator);
 }
 @end

--- a/LDEventSource/Info.plist
+++ b/LDEventSource/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.2.6</string>
+	<string>3.2.7</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/LDEventSource/LDEventSource.m
+++ b/LDEventSource/LDEventSource.m
@@ -155,10 +155,13 @@ didReceiveResponse:(NSURLResponse *)response completionHandler:(void (^)(NSURLSe
 - (void)URLSession:(NSURLSession *)session dataTask:(NSURLSessionDataTask *)dataTask didReceiveData:(NSData *)data
 {
     NSString *eventString = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
-    [self.eventStringAccumulator accumulateEventStringWithString:eventString];
-    if ([self.eventStringAccumulator isReadyToParseEvent]) {
-        [self parseEventString:self.eventStringAccumulator.eventString];
-        [self.eventStringAccumulator reset];
+    @synchronized(self) {
+        [self.eventStringAccumulator accumulateEventStringWithString:eventString];
+        if ([self.eventStringAccumulator isReadyToParseEvent]) {
+            NSString *eventString = [self.eventStringAccumulator.eventString copy];
+            [self.eventStringAccumulator reset];
+            [self parseEventString:eventString];
+        }
     }
 }
 

--- a/LDEventSource/LDEventSource.m
+++ b/LDEventSource/LDEventSource.m
@@ -158,9 +158,9 @@ didReceiveResponse:(NSURLResponse *)response completionHandler:(void (^)(NSURLSe
     @synchronized(self) {
         [self.eventStringAccumulator accumulateEventStringWithString:eventString];
         if ([self.eventStringAccumulator isReadyToParseEvent]) {
-            NSString *eventString = [self.eventStringAccumulator.eventString copy];
+            NSString *accumulatedEventString = [self.eventStringAccumulator.eventString copy];
             [self.eventStringAccumulator reset];
-            [self parseEventString:eventString];
+            [self parseEventString:accumulatedEventString];
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ source 'https://github.com/CocoaPods/Specs.git'
 platform :ios, '8.0'
 
 target 'TargetName' do
-pod 'DarklyEventSource', '~> 3.2.6'
+pod 'DarklyEventSource', '~> 3.2.7'
 end
 ```
 
@@ -117,7 +117,7 @@ $ brew install carthage
 To integrate EventSource into your Xcode project using Carthage, specify it in your `Cartfile`:
 
 ```ogdl
-github "launchdarkly/ios-eventsource" >= 3.2.6
+github "launchdarkly/ios-eventsource" >= 3.2.7
 ```
 
 Run `carthage` to build the framework and drag the built `EventSource.framework` into your Xcode project.


### PR DESCRIPTION
Hardens DarklyEventSource against multiple threads calling into NSURLSession delegate method `didReceiveData`.