### PR TITLE
Fixed issue with parsing SSE event headers

### DIFF
--- a/LDEventSource/LDEventParser.m
+++ b/LDEventSource/LDEventParser.m
@@ -75,7 +75,7 @@
                     event.id = value;
                 } else if ([key isEqualToString:LDEventKeyRetry]) {
                     if ([value isKindOfClass:[NSNumber class]]) {
-                        self.retryInterval = @([value doubleValue]);
+                        self.retryInterval = @([value doubleValue]/1000);
                     }
                 }
             }


### PR DESCRIPTION
Details:
According to SSE Spec at https://www.w3.org/TR/2009/WD-eventsource-20090421/#concept-event-stream-reconnection-time, retry header in event source response should be passed (and interpreted) as milliseconds. Current implementation was interpreting it as seconds.