### PR TITLE
Version 4.0.2

### DIFF
--- a/LDEventSource/LDEventSource.h
+++ b/LDEventSource/LDEventSource.h
@@ -47,6 +47,8 @@ typedef void (^LDEventSourceEventHandler)(LDEvent * _Nullable event);
 /// Connect to and receive Server-Sent Events (SSEs).
 @interface LDEventSource : NSObject
 
+@property (nonatomic, strong, nullable) NSURLSessionDataTask *eventSourceTask;
+
 /// Returns a new instance of EventSource with the specified URL.
 ///
 /// @param URL The URL of the EventSource.


### PR DESCRIPTION
There are currently PRs open against the source repository to fix a memory leak in EventSource, and several of the other forks have already merged fixes for this.
 
I am still working to confirm for certain that this is the source of our crashes in the LD SDK, but perhaps it will aid your investigation.