### PR TITLE
add DEFINES_MODULES

### DIFF
--- a/DarklyEventSource.podspec
+++ b/DarklyEventSource.podspec
@@ -12,5 +12,5 @@ Pod::Spec.new do |s|
 	s.watchos.deployment_target = '2.0'
 	s.tvos.deployment_target = '9.0'
 	s.requires_arc = true
-	s.xcconfig = { 'OTHER_LDFLAGS' => '-lobjc' }
+	s.xcconfig = { 'DEFINES_MODULE' => 'YES', 'OTHER_LDFLAGS' => '-lobjc' }
 end


### PR DESCRIPTION
Changes based on [this comment](https://github.com/launchdarkly/react-native-client-sdk/issues/22#issuecomment-542302858).

This is necessary to use launchdarkly without `use_frameworks` in the podfile.