### PR TITLE
Prepare 4.1.0 release

### DIFF
--- a/DarklyEventSource.podspec
+++ b/DarklyEventSource.podspec
@@ -12,5 +12,6 @@ Pod::Spec.new do |s|
 	s.watchos.deployment_target = '2.0'
 	s.tvos.deployment_target = '9.0'
 	s.requires_arc = true
+	s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
 	s.xcconfig = { 'OTHER_LDFLAGS' => '-lobjc' }
 end

--- a/DarklyEventSource.podspec
+++ b/DarklyEventSource.podspec
@@ -1,11 +1,11 @@
 Pod::Spec.new do |s|
 	s.name         = "DarklyEventSource"
-	s.version      = "4.0.3"
+	s.version      = "4.1.0"
 	s.summary      = "HTML5 Server-Sent Events in your Cocoa app."
 	s.homepage     = "https://github.com/launchdarkly/ios-eventsource"
 	s.license      = 'MIT (see LICENSE.txt)'
 	s.author       = { "Neil Cowburn" => "git@neilcowburn.com" }
-	s.source       = { :git => "https://github.com/launchdarkly/ios-eventsource.git", :tag => '4.0.3' }
+	s.source       = { :git => "https://github.com/launchdarkly/ios-eventsource.git", :tag => '4.1.0' }
 	s.source_files = 'LDEventSource/**/*.{h,m}'
 	s.ios.deployment_target = '8.0'
 	s.osx.deployment_target = '10.10'

--- a/LDEventSource/Info.plist
+++ b/LDEventSource/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>4.0.2</string>
+	<string>4.1.0</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ source 'https://github.com/CocoaPods/Specs.git'
 platform :ios, '8.0'
 
 target 'TargetName' do
-pod 'DarklyEventSource', '~> 4.0.3'
+pod 'DarklyEventSource', '~> 4.1.0'
 end
 ```
 
@@ -130,7 +130,7 @@ $ brew install carthage
 To integrate EventSource into your Xcode project using Carthage, specify it in your `Cartfile`:
 
 ```ogdl
-github "launchdarkly/ios-eventsource" >= 4.0.3
+github "launchdarkly/ios-eventsource" >= 4.1.0
 ```
 
 Run `carthage` to build the framework and drag the built `EventSource.framework` into your Xcode project.


### PR DESCRIPTION
Adds `use_frameworks!` fix for React Native suggested by @hkellaway

Added `s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }` which allows React Native to `pod install` and build without `use_frameworks!`. This change does not affect the iOS SDK.