### PR TITLE
fix "NSArray was mutated while being enumerated"

### DIFF
--- a/LDEventSource/LDEventSource.m
+++ b/LDEventSource/LDEventSource.m
@@ -272,7 +272,8 @@ didReceiveResponse:(NSURLResponse *)response completionHandler:(void (^)(NSURLSe
 - (void)_dispatchEvent:(LDEvent *)event type:(NSString * const)type
 {
     NSArray *eventHandlers = self.listeners[type];
-    for (LDEventSourceEventHandler handler in eventHandlers) {
+    for (int i=0; i < eventHandlers.count; i++) {
+        LDEventSourceEventHandler handler = eventHandlers[i];
         dispatch_async(connectionQueue, ^{
             handler(event);
         });


### PR DESCRIPTION
This PR changes processing event handlers so it iterates the array of listeners the old-fashioned way -- by index -- rather than using `in handlers`, in order to avoid "mutated while being enumerated" errors.

I ran into this when using the code with my [Capacitor plugin](https://github.com/RangerRick/capacitor-eventsource.git)  because I was adding and removing event listeners in different bits of my client code somewhat regularly.