### PR TITLE
Prepare 4.1.1 release

### DIFF
--- a/DarklyEventSource.podspec
+++ b/DarklyEventSource.podspec
@@ -1,11 +1,11 @@
 Pod::Spec.new do |s|
 	s.name         = "DarklyEventSource"
-	s.version      = "4.1.0"
+	s.version      = "4.1.1"
 	s.summary      = "HTML5 Server-Sent Events in your Cocoa app."
 	s.homepage     = "https://github.com/launchdarkly/ios-eventsource"
 	s.license      = 'MIT (see LICENSE.txt)'
 	s.author       = { "Neil Cowburn" => "git@neilcowburn.com" }
-	s.source       = { :git => "https://github.com/launchdarkly/ios-eventsource.git", :tag => '4.1.0' }
+	s.source       = { :git => "https://github.com/launchdarkly/ios-eventsource.git", :tag => '4.1.1' }
 	s.source_files = 'LDEventSource/**/*.{h,m}'
 	s.ios.deployment_target = '8.0'
 	s.osx.deployment_target = '10.10'

--- a/LDEventSource/Info.plist
+++ b/LDEventSource/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>4.1.0</string>
+	<string>4.1.1</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # EventSource
 **Server-Sent Events for iOS, watchOS, tvOS and macOS**
 
+_This library is deprecated, slated to become unmaintained in July 2021. LaunchDarkly's [iOS SDK](https://github.com/launchdarkly/ios-client-sdk) has moved to using a new [Swift SSE](https://github.com/launchdarkly/swift-eventsource) library as a replacement._
+
 ![Travis](https://travis-ci.org/neilco/EventSource.svg?branch=master)
 [![CocoaPods Compatible](https://img.shields.io/cocoapods/v/DarklyEventSource.svg)](https://img.shields.io/cocoapods/v/DarklyEventSource.svg)
 [![Carthage Compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
@@ -106,7 +108,7 @@ source 'https://github.com/CocoaPods/Specs.git'
 platform :ios, '8.0'
 
 target 'TargetName' do
-pod 'DarklyEventSource', '~> 4.1.0'
+pod 'DarklyEventSource', '~> 4.1.1'
 end
 ```
 
@@ -130,7 +132,7 @@ $ brew install carthage
 To integrate EventSource into your Xcode project using Carthage, specify it in your `Cartfile`:
 
 ```ogdl
-github "launchdarkly/ios-eventsource" >= 4.1.0
+github "launchdarkly/ios-eventsource" >= 4.1.1
 ```
 
 Run `carthage` to build the framework and drag the built `EventSource.framework` into your Xcode project.


### PR DESCRIPTION
## [4.1.1] - 2020-09-11

### Fixed
- Thanks to @RangerRick fo PR [#32](https://github.com/launchdarkly/ios-eventsource/pull/32), fixing "NSArray was mutated while being enumerated" exceptions when adding listeners while events are being dispatched.
